### PR TITLE
Non blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 repository = "https://github.com/maxjoehnk/helios-dac-rs"
 
 [features]
-default = ["sdk"]
+default = ["native"]
 
 sdk = ["helios-dac-sys"]
 native = ["rusb", "thiserror"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ members = ["helios-dac-sys"]
 [package]
 name = "helios-dac"
 description = "library to interact with the [Helios Laser DAC](https://bitlasers.com/helios-laser-dac/)"
-version = "0.1.1"
-authors = ["Max Jöhnk <maxjoehnk@gmail.com>", "seem-less <contact@waseem-g.com>"]
+version = "0.1.0"
+authors = ["Max Jöhnk <maxjoehnk@gmail.com>", "Waseem G <contact@waseem-g.com>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/maxjoehnk/helios-dac-rs"
 
 [features]
-default = ["native"]
+default = ["sdk"]
 
 sdk = ["helios-dac-sys"]
 native = ["rusb", "thiserror"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["helios-dac-sys"]
 [package]
 name = "helios-dac"
 description = "library to interact with the [Helios Laser DAC](https://bitlasers.com/helios-laser-dac/)"
-version = "0.1.0"
-authors = ["Max Jöhnk <maxjoehnk@gmail.com>"]
+version = "0.1.1"
+authors = ["Max Jöhnk <maxjoehnk@gmail.com>", "seem-less <contact@waseem-g.com>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/maxjoehnk/helios-dac-rs"

--- a/examples/frames.rs
+++ b/examples/frames.rs
@@ -1,4 +1,4 @@
-use helios_dac::{Frame, Point, Coordinate, Color};
+use helios_dac::{Frame, Point, Coordinate, Color, WriteFrameFlags};
 
 #[cfg(all(feature = "sdk", not(feature = "native")))]
 pub fn main() {
@@ -20,7 +20,9 @@ pub fn main() {
 
 #[cfg(feature = "native")]
 pub fn main() {
-    use helios_dac::NativeHeliosDacController;
+    use std::{time::Duration, thread};
+
+    use helios_dac::{NativeHeliosDacController, DeviceStatus};
 
     let frames = get_frames();
 
@@ -31,8 +33,13 @@ pub fn main() {
         let mut device = device.open().unwrap();
 
         for frame in frames.clone() {
-            println!("status: {:?}", device.status().unwrap());
-            device.write_frame(frame).unwrap();
+            // if let Ok(DeviceStatus::Ready) = device.status(){
+                // println!("writing...");
+                device.write_frame(frame).unwrap();
+            // }else{
+                // println!("dac was not ready");
+            // }
+            // thread::sleep(Duration::from_millis(40));
         }
 
         device.stop().unwrap();
@@ -61,7 +68,8 @@ fn get_frames() -> Vec<Frame> {
             });
         }
 
-        frames.push(Frame::new(30000, points));
+        // frames.push(Frame::new(30000, points));
+        frames.push(Frame::new_with_flags(30000, points,WriteFrameFlags::DONT_BLOCK));
     }
 
     frames


### PR DESCRIPTION
Implemented another thread responsible for sending frames to the DAC. Frames are sent to the thread through a channel, the thread then sends the first frame in the channel queue to the DAC when it's status is ready.

Tested using a Helios DAC and Laserworld CS-2000RGB-FX laser.